### PR TITLE
Define long for Python 3

### DIFF
--- a/tensorflow_transform/coders/csv_coder.py
+++ b/tensorflow_transform/coders/csv_coder.py
@@ -25,10 +25,8 @@ import six
 from six.moves import cStringIO
 import tensorflow as tf
 
-try:
-  long        # Python 2
-except NameError:
-  long = int  # Python 3
+if six.PY3:
+  long = int  # pylint: disable=redefined-builtin,invalid-name
 
 
 def _make_cast_fn(dtype):

--- a/tensorflow_transform/coders/csv_coder.py
+++ b/tensorflow_transform/coders/csv_coder.py
@@ -25,6 +25,11 @@ import six
 from six.moves import cStringIO
 import tensorflow as tf
 
+try:
+  long        # Python 2
+except NameError:
+  long = int  # Python 3
+
 
 def _make_cast_fn(dtype):
   """Return a function to extract the typed value from the feature.


### PR DESCRIPTION
Long was removed from Python 3, use int instead.  Long is used on lines 246 and 248.