### PR TITLE
from six import integer_types, string_types

### DIFF
--- a/tensorflow_transform/beam/common.py
+++ b/tensorflow_transform/beam/common.py
@@ -19,7 +19,8 @@ from __future__ import print_function
 
 
 from apache_beam.typehints import Union
-from six import integer_types, string_types
+from six import integer_types
+from six import string_types
 
-NUMERIC_TYPE = Union[float, integer_types]
-PRIMITIVE_TYPE = Union[NUMERIC_TYPE, string_types]
+NUMERIC_TYPE = Union[float, Union[integer_types]]
+PRIMITIVE_TYPE = Union[NUMERIC_TYPE, Union[string_types]]

--- a/tensorflow_transform/beam/common.py
+++ b/tensorflow_transform/beam/common.py
@@ -22,4 +22,4 @@ from apache_beam.typehints import Union
 from six import integer_types, string_types
 
 NUMERIC_TYPE = Union[float, integer_types]
-PRIMITIVE_TYPE = Union[NUMERIC_TYPE, str, string_types]
+PRIMITIVE_TYPE = Union[NUMERIC_TYPE, string_types]

--- a/tensorflow_transform/beam/common.py
+++ b/tensorflow_transform/beam/common.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 
 
 from apache_beam.typehints import Union
+from six import integer_types, string_types
 
-NUMERIC_TYPE = Union[float, int, long]
-PRIMITIVE_TYPE = Union[NUMERIC_TYPE, str, unicode]
+NUMERIC_TYPE = Union[float, integer_types]
+PRIMITIVE_TYPE = Union[NUMERIC_TYPE, str, string_types]


### PR DESCRIPTION
Both `long` and `unicode` were dropped from Python 3.  I am __not sure if this is the correct approach__ but I know that Python 3 will not be happy with the presence of long and unicode in this code.  https://pythonhosted.org/six/#constants