### PR TITLE
Update getting_started.md

### DIFF
--- a/getting_started.md
+++ b/getting_started.md
@@ -121,7 +121,7 @@ raw_data = [
 raw_data_metadata = ...
 transformed_dataset, transform_fn = (
     (raw_data, raw_data_metadata) | beam_impl.AnalyzeAndTransformDataset(
-        preprocessing_fn, tempfile.mkdtemp()))
+        preprocessing_fn))
 transformed_data, transformed_metadata = transformed_dataset
 ```
 


### PR DESCRIPTION
Temp dir can no longer be passed as an argument, must use beam_impl.Context. (Also, the error when context is not used should be improved, as it's not obvious what the problem is, or there should be a sane default.)