### PR TITLE
Removed unused reduce_instance_dims arg in _NumPyCombinerSpec doc

### DIFF
--- a/tensorflow_transform/analyzers.py
+++ b/tensorflow_transform/analyzers.py
@@ -264,7 +264,6 @@ class _NumPyCombinerSpec(CombinerSpec):
 
   Args:
     fn: The numpy function representing the reduction to be done.
-    reduce_instance_dims: Whether to reduce across non-batch dimensions.
     output_dtypes: The numpy dtype to cast each output to.
   """
 


### PR DESCRIPTION
`reduce_instance_dims` does not exist in `_NumPyCombinerSpec`'s constructor.