### PR TITLE
Define cmp() in Python 3

### DIFF
--- a/tensorflow_transform/beam/impl_test.py
+++ b/tensorflow_transform/beam/impl_test.py
@@ -44,6 +44,12 @@ from google.protobuf import text_format
 import unittest
 from tensorflow.core.example import example_pb2
 
+try:
+  cmp             # Python 2
+except NameError:
+  def cmp(x, y):  # Python 3
+    return (x > y) - (x < y)
+
 
 def _construct_test_bucketization_parameters():
   args_without_dtype = (


### PR DESCRIPTION
The builtin __cmp()__ was removed in Python 3.

[flake8](http://flake8.pycqa.org) testing of https://github.com/tensorflow/transform on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tensorflow_transform/beam/impl_test.py:2497:14: F821 undefined name 'cmp'
      return cmp(a[1], b[1])
             ^
1     F821 undefined name 'cmp'
1
```