### PR TITLE
added default value param to sparse_tensor_to_dense_with_shape mappers

### DIFF
--- a/tensorflow_transform/mappers.py
+++ b/tensorflow_transform/mappers.py
@@ -66,13 +66,13 @@ from tensorflow.python.ops import lookup_ops
 from tensorflow.python.util import deprecation
 
 
-def sparse_tensor_to_dense_with_shape(x, shape):
+def sparse_tensor_to_dense_with_shape(x, shape, default_value=0):
   """Converts a `SparseTensor` into a dense tensor and sets its shape.
 
   Args:
     x: A `SparseTensor`.
     shape: The desired shape of the densified `Tensor`.
-
+    default_value: Value to set for indices not specified in sparse_indices. Defaults to zero. 
   Returns:
     A `Tensor` with the desired shape.
 
@@ -85,7 +85,7 @@ def sparse_tensor_to_dense_with_shape(x, shape):
       x.dense_shape[i] if size is None else size
       for i, size in enumerate(shape)
   ]
-  dense = tf.sparse_to_dense(x.indices, new_dense_shape, x.values)
+  dense = tf.sparse_to_dense(x.indices, new_dense_shape, x.values, default_value)
   dense.set_shape(shape)
   return dense
 


### PR DESCRIPTION
I was using tf.string_split to split string and the convert the sparse tensor to dense using sparse_tensor_to_dense_with_shape, but then I found that default value was integer (default:0). I was getting type error. So I changed function definition to have one more parameter default_value.