### PR TITLE
from typing import Any, Callable

### DIFF
--- a/tensorflow_transform/beam/shared.py
+++ b/tensorflow_transform/beam/shared.py
@@ -52,6 +52,8 @@ import threading
 import uuid
 import weakref
 
+from typing import Any, Callable
+
 
 class _SharedControlBlock(object):
   """Wrapper class for holding objects in the SharedMap.


### PR DESCRIPTION
These are used in type hints in this file.

https://docs.python.org/3/library/typing.html


flake8 testing of https://github.com/tensorflow/transform on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tensorflow_transform/beam/shared.py:68:5: F821 undefined name 'Callable'
    # type: (Callable[[], Any])
    ^
./tensorflow_transform/beam/shared.py:68:5: F821 undefined name 'Any'
    # type: (Callable[[], Any])
    ^
./tensorflow_transform/beam/shared.py:163:5: F821 undefined name 'Callable'
    # type: (bytes, Callable[[], Any])
    ^
./tensorflow_transform/beam/shared.py:163:5: F821 undefined name 'Any'
    # type: (bytes, Callable[[], Any])
    ^
./tensorflow_transform/beam/shared.py:208:5: F821 undefined name 'Callable'
    # type: (Callable[[], Any])
    ^
./tensorflow_transform/beam/shared.py:208:5: F821 undefined name 'Any'
    # type: (Callable[[], Any])
    ^
6     F821 undefined name 'Callable'
6
```