### PR TITLE
Relax upper bound for pydot

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def _make_required_install_packages():
       # between CPU and GPU installation.
       # 'tensorflow>=1.14,<2',
 
-      'pydot>=1.2.0,<1.3',
+      'pydot>=1.2.0,<2',
   ]
 
 # TODO(b/121329572): Remove the following comment after we can guarantee the


### PR DESCRIPTION
Current version of pydot is 1.4.1. Updating setup.py to pick up new version until the next major version 2. This also matches Beam's version requirements for the same dependency.

See: https://github.com/apache/beam/pull/9113 for the relevant Beam change.