### PR TITLE
Fixed schema related issues for census example.

### DIFF
--- a/examples/census_example_common.py
+++ b/examples/census_example_common.py
@@ -22,8 +22,8 @@ import apache_beam as beam
 import tensorflow.compat.v2 as tf
 import tensorflow_transform as tft
 import tensorflow_transform.beam as tft_beam
-from tensorflow_transform.tf_metadata import dataset_metadata
-from tfx_bsl.public.tfxio import RecordBatchToExamplesEncoder
+from tensorflow_transform.tf_metadata import schema_utils
+from tfx_bsl.coders.example_coder import RecordBatchToExamplesEncoder
 from tfx_bsl.public import tfxio
 
 CATEGORICAL_FEATURE_KEYS = [
@@ -64,8 +64,8 @@ RAW_DATA_FEATURE_SPEC = dict([(name, tf.io.FixedLenFeature([], tf.string))
                              [(LABEL_KEY,
                                tf.io.FixedLenFeature([], tf.string))])
 
-_SCHEMA = dataset_metadata.DatasetMetadata.from_feature_spec(
-    RAW_DATA_FEATURE_SPEC).schema
+_SCHEMA = schema_utils.schema_from_feature_spec(
+    RAW_DATA_FEATURE_SPEC)
 
 # Constants used for training.  Note that the number of instances will be
 # computed by tf.Transform in future versions, in which case it can be read from
@@ -217,7 +217,7 @@ def transform_data(train_data_file, test_data_file, working_dir):
 
       # Extract transformed RecordBatches, encode and write them to the given
       # directory.
-      coder = RecordBatchToExamplesEncoder()
+      coder = RecordBatchToExamplesEncoder(_SCHEMA)
       _ = (
           transformed_data
           | 'EncodeTrainData' >>


### PR DESCRIPTION
# Summary of Changes

It appears some of the schema related functionality was pointing to old locations, which was causing census_example_v2.py to break.  This pull request fixes these schema related issues and makes it so that census_example_v2.py now works with

```
python census_example_v2.py --input_data_dir data --working_dir working_area
```

# Details

dataset_metadata has been replaced by schema_utils in imports and
RecordBatchToExamplesEncoder is now imported from tfx_bsl.coders.example_coder.
schema_from_feature_spec is now being called from schema_utils, and
RecordBatchToExamplesEncoder is now passed the schema, which was missing
earlier.
_RAW_DATA_METADATA schema creation also fixed by pointing it to
schema_utils.from_feature_spec.  The net result is census_example_v2.py
now works as expected.