### PR TITLE
Fix to only transform raw data when requested.

### DIFF
--- a/examples/census_example_v2.py
+++ b/examples/census_example_v2.py
@@ -237,11 +237,11 @@ def main(input_data_dir,
   train_data_file = os.path.join(input_data_dir, 'adult.data')
   test_data_file = os.path.join(input_data_dir, 'adult.test')
 
-  common.transform_data(train_data_file, test_data_file, working_dir)
 
   if read_raw_data_for_training:
     raw_train_and_eval_patterns = (train_data_file, test_data_file)
     transformed_train_and_eval_patterns = None
+    common.transform_data(train_data_file, test_data_file, working_dir)
   else:
     train_pattern = os.path.join(working_dir,
                                  common.TRANSFORMED_TRAIN_DATA_FILEBASE + '*')


### PR DESCRIPTION
# Scenario

When there is already pre-processed data available, and the user wants to re-use that data by passing read_raw_data_for_training=False to main, the flow was calling common.transform_data again on the raw data. This was causing WriteTransformFn to fail because there are already existing artifacts there, and unnecessarily recomputing statistics etc. 

# Fix

This fix moves the common.transform_data invocation to where we are processing the raw data for the first time.