### PR TITLE
Fixed incorrect getting started link in README.md in examples directory

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ There's a minimal TFX example available in the [GitHub repo](./simple_example.py
 The *Census income* dataset is provided by the
 [UCI Machine Learning Repository](https://archive.ics.uci.edu/ml/datasets/Census+Income).
 This dataset contains both categorical and numeric data. See
-[Get started with TensorFlow Transform](https://www.tensorflow.org/tfx/transform/get_started)
+[Get started with TensorFlow Transform](https://github.com/tensorflow/transform/blob/master/docs/get_started.ipynb)
 for details.
 
 ## Sentiment analysis example

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ There's a minimal TFX example available in the [GitHub repo](./simple_example.py
 The *Census income* dataset is provided by the
 [UCI Machine Learning Repository](https://archive.ics.uci.edu/ml/datasets/Census+Income).
 This dataset contains both categorical and numeric data. See
-[Get started with TensorFlow Transform](https://github.com/tensorflow/transform/blob/master/docs/get_started.md)
+[Get started with TensorFlow Transform](https://www.tensorflow.org/tfx/transform/get_started)
 for details.
 
 ## Sentiment analysis example


### PR DESCRIPTION
Now link points to https://www.tensorflow.org/tfx/transform/get_started