### PR TITLE
Shape related code updated to address TODO(b/208879020)

### DIFF
--- a/examples/census_example_common.py
+++ b/examples/census_example_common.py
@@ -127,7 +127,7 @@ def transform_data(train_data_file, test_data_file, working_dir):
     for key in OPTIONAL_NUMERIC_FEATURE_KEYS:
       # This is being treated as a dense tensor that might be missing
       # values. Might call for some sort of imputation.
-      outputs[key] = tf.identity(inputs[key])
+      outputs[key] = tft.scale_to_0_1(inputs[key])
 
     # For all categorical columns except the label column, we generate a
     # vocabulary, and convert the string feature to a one-hot encoding.

--- a/examples/census_example_v2.py
+++ b/examples/census_example_v2.py
@@ -237,11 +237,11 @@ def main(input_data_dir,
   train_data_file = os.path.join(input_data_dir, 'adult.data')
   test_data_file = os.path.join(input_data_dir, 'adult.test')
 
-  common.transform_data(train_data_file, test_data_file, working_dir)
 
   if read_raw_data_for_training:
     raw_train_and_eval_patterns = (train_data_file, test_data_file)
     transformed_train_and_eval_patterns = None
+    common.transform_data(train_data_file, test_data_file, working_dir)
   else:
     train_pattern = os.path.join(working_dir,
                                  common.TRANSFORMED_TRAIN_DATA_FILEBASE + '*')


### PR DESCRIPTION
# Summary of change

Shape related code has been updated to treat each observation as a tensor of shape (1,).

# Details

The feature spec is updated to use shape (1,), and therefore the schema as well.  ```education-num``` is now treated as a dense tensor instead of sparse as it may be missing values, but it does not vary in its length to warrant treatment as a ```RaggedTensor```.  ```transform_dataset``` is updated to reshape the raw data so each observation is transformed to be of shape (1,) before passing through ```tft_layer```.  This pull request includes [pr268](https://github.com/tensorflow/transform/pull/268).  I am open to making them independent of each other and any other feedback. I would like to make a notebook version of this example that walks through the entire lifecycle of the workflow in the context of tft. The details are in that pull request, but I would like to expand it to be more instructive through interactivity.  