### PR TITLE
Add a build workflow for the project

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,64 @@
+name: Build Wheels & Publish to PyPI
+
+on:
+  pull_request:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  build-package:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v4
+
+    - name: Set up python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: Install python dependencies
+      run: pip install build twine
+
+    - name: Build sdist and wheel
+      run: |
+        python -m build -o wheelhouse
+
+    - name: List and check sdist
+      run: |
+        ls -lh wheelhouse/
+        twine check wheelhouse/*
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: sdist
+        path: ./wheelhouse/*.tar.gz
+
+  upload_to_pypi:
+    name: Upload to PyPI
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'release' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'workflow_dispatch')
+    needs: [build-package]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/tensorflow-transform
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: wheels/
+
+      - name: List the build artifacts
+        run: |
+          ls -lAs wheels/
+
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1.9
+        with:
+          packages_dir: wheels/


### PR DESCRIPTION
This PR adds a build workflow for the project which

* Checks that wheels can still be built when a PR is made
* If a release is made, a wheel and sdist is generated and uploaded to the PyPI automatically
* Releases can also manually be triggered with a workflow dispatch