### PR TITLE
build: relax dependency constraints for Python 3.12 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,19 +49,19 @@ def _make_required_install_packages():
         "numpy>=1.22.0",
         'protobuf>=4.25.2,<6.0.0;python_version>="3.11"',
         'protobuf>=4.21.6,<6.0.0;python_version<"3.11"',
-        "pyarrow>=10,<11",
+        "pyarrow>=10",
         "pydot>=1.2,<2",
-        "tensorflow>=2.17,<2.18",
+        "tensorflow>=2.16,<2.18",
         "tensorflow-metadata"
         + select_constraint(
-            default=">=1.17.1,<1.18.0",
+            default=">=1.17.0,<1.18.0",
             nightly=">=1.18.0.dev",
             git_master="@git+https://github.com/tensorflow/metadata@master",
         ),
         "tf_keras>=2",
         "tfx-bsl"
         + select_constraint(
-            default=">=1.17.1,<1.18.0",
+            default=">=1.17.0,<1.18.0",
             nightly=">=1.18.0.dev",
             git_master="@git+https://github.com/tensorflow/tfx-bsl@master",
         ),


### PR DESCRIPTION
This commit updates the package dependencies in setup.py to allow TensorFlow Transform to be installed in modern Python 3.12 environments alongside locally compiled TFX components.

Specific changes include:
* Unpin PyArrow: Removed the `<11` upper bound on `pyarrow` to allow modern versions (e.g., 14+) to resolve, avoiding legacy Arrow 10 build failures during wheel installation.
* Broaden TensorFlow: Relaxed the `tensorflow` requirement to `>=2.16,<2.18` for broader compatibility.
* Adjust Component Bounds: Lowered the minimum required versions for `tensorflow-metadata` and `tfx-bsl` from `1.17.1` to `1.17.0` so pip can cleanly resolve the custom-built local wheels from previous steps.