### PR TITLE
Update TFX-bsl and TFMD version constraints in setup.py to its master and pinning Bazel version to 7.7.0

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -9,6 +9,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+env:
+  USE_BAZEL_VERSION: 7.7.0
+
 jobs:
   unit-tests:
     if: github.actor != 'copybara-service[bot]'
@@ -31,7 +34,10 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install .[test]
+        sudo apt update
+        sudo apt install -y protobuf-compiler
+        pip install --upgrade pip setuptools wheel numpy pyarrow
+        pip install --no-build-isolation .[test]
 
     - name: Run unit tests
       shell: bash

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -6,6 +6,9 @@ on:
   release:
     types: [published]
 
+env:
+  USE_BAZEL_VERSION: 7.7.0
+
 jobs:
   build-package:
     name: Build sdist
@@ -20,11 +23,15 @@ jobs:
         python-version: '3.10'
 
     - name: Install python dependencies
-      run: pip install --upgrade pip build twine
+      run: |
+        sudo apt update
+        sudo apt install -y protobuf-compiler
+        pip install --upgrade pip setuptools wheel numpy pyarrow build twine
+        pip install --no-build-isolation .
 
     - name: Build sdist and wheel
       run: |
-        python -m build --sdist --wheel -o wheelhouse
+        python -m build --sdist --wheel --no-isolation -o wheelhouse
 
     - name: List and check sdist
       run: |

--- a/setup.py
+++ b/setup.py
@@ -52,12 +52,12 @@ def _make_required_install_packages():
         "tensorflow>=2.21,<2.22",
         "tensorflow-metadata"
         + select_constraint(
-            default=">=1.17.1,<1.18.0",
+            default="@git+https://github.com/tensorflow/metadata@master",
             nightly=">=1.18.0.dev",
             git_master="@git+https://github.com/tensorflow/metadata@master",
         ),
         "tf_keras>=2",
-        "tfx-bsl@git+https://github.com/tensorflow/tfx-bsl.git@master",
+        "tfx-bsl@git+https://github.com/tensorflow/tfx-bsl.git@testing",
     ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ def _make_required_install_packages():
             git_master="@git+https://github.com/tensorflow/metadata@master",
         ),
         "tf_keras>=2",
-        "tfx-bsl@git+https://github.com/tensorflow/tfx-bsl.git@testing",
+        "tfx-bsl@git+https://github.com/vkarampudi/tfx-bsl.git@testing",
     ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ def _make_required_install_packages():
             git_master="@git+https://github.com/tensorflow/metadata@master",
         ),
         "tf_keras>=2",
-        "tfx-bsl@git+https://github.com/vkarampudi/tfx-bsl.git@testing",
+        "tfx-bsl@git+https://github.com/vkarampudi/tfx-bsl@testing",
     ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ def _make_required_install_packages():
             git_master="@git+https://github.com/tensorflow/metadata@master",
         ),
         "tf_keras>=2",
-        "tfx-bsl@git+https://github.com/vkarampudi/tfx-bsl@testing",
+        "tfx-bsl@git+https://github.com/tensorflow/tfx-bsl@master",
     ]
 
 


### PR DESCRIPTION
## Summary
This PR updates the `tfx-bsl` and `tfmd` dependency references to point to the official repository's `master` branch and introduces stability fixes to the GitHub Actions workflows to resolve Bazel and PIP build isolation conflicts.

---

## Key Changes

### 1. Dependency Cleanups (`setup.py`)
* **Point `tfx-bsl` to Master:** Reverted testing fork references and pointed the `tfx-bsl` and `tfmd` git references to the official `tensorflow/tfx-bsl@master` `tensorflow/metadata@master` branchs.
* **URL Normalization:** Cleaned up/normalized the dependency git URL format to prevent pip installation conflicts.

### 2. CI Workflow Stability Fixes (`.github/workflows/`)
* **Bazel Version Pinning:** Set `USE_BAZEL_VERSION: 7.7.0` globally in both the `ci-test.yml` and `wheels.yml` environments. This prevents the runner from downloading incompatible newer versions of Bazel (e.g., `9.x`) that cause build errors (such as `name 'sh_binary' is not defined`) during dependency compilation.
* **Bypass Build Isolation Conflicts:** 
  * Added pre-installation of build-time dependencies (`setuptools`, `wheel`, `numpy`, and `pyarrow`) in the runner environment.
  * Updated the dependency installation steps to use `--no-build-isolation` (e.g., `pip install --no-build-isolation .[test]`).
  * Configured the package build step in the wheels workflow to run with `--no-isolation` (e.g., `python -m build --no-isolation`).
  
  *Reasoning:* This completely avoids PEP 517 isolated environment setups where pip-generated `sitecustomize.py` assertions (`assert not path in sys.path`) collide with environment `PYTHONPATH` variables forwarded by Bazel's sandboxed sub-shells.

---

## Verification & Status
* All pipeline builds and dependencies now compile successfully on all matrix runner environments.
* Workflows complete successfully (Green).
