### PR TITLE
Align master for 1.22.0 development after 1.21.0 release (#350)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -66,6 +66,9 @@ jobs:
           ls -lAs wheels/
 
       - name: Upload to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.9
+        uses: pypa/gh-action-pypi-publish@release/v1.12
         with:
-          packages_dir: wheels/
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: wheels/
+          verify-metadata: false
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # TensorFlow Transform
 
-[![Python](https://img.shields.io/badge/python%7C3.9%7C3.10%7C3.11-blue)](https://github.com/tensorflow/transform)
+[![Python](https://img.shields.io/badge/python%7C3.10%7C3.11%7C3.12%7C3.13-blue)](https://github.com/tensorflow/transform)
 [![PyPI](https://badge.fury.io/py/tensorflow-transform.svg)](https://badge.fury.io/py/tensorflow-transform)
 [![Documentation](https://img.shields.io/badge/api-reference-blue.svg)](https://www.tensorflow.org/tfx/transform/api_docs/python/tft)
 
@@ -107,7 +107,8 @@ other *untested* combinations may also work.
 
 tensorflow-transform                                                            | apache-beam[gcp] | pyarrow | tensorflow        | tensorflow-metadata | tfx-bsl |
 ------------------------------------------------------------------------------- | -----------------| --------|-------------------|---------------------|---------|
-[GitHub master](https://github.com/tensorflow/transform/blob/master/RELEASE.md) | 2.65.0           | 10.0.1  | nightly (2.x)     | 1.17.1              | 1.17.1  |
+[GitHub master](https://github.com/tensorflow/transform/blob/master/RELEASE.md) | 2.72.0           | 14.0.0  | nightly (2.x)     | 1.21.0              | 1.21.0  |
+[1.21.0](https://github.com/tensorflow/transform/blob/v1.21.0/RELEASE.md)       | 2.72.0           | 14.0.0  | 2.21              | 1.21.0              | 1.21.0  |
 [1.17.0](https://github.com/tensorflow/transform/blob/v1.17.0/RELEASE.md)       | 2.65.0           | 10.0.1  | 2.17              | 1.17.1              | 1.17.1  |
 [1.16.0](https://github.com/tensorflow/transform/blob/v1.16.0/RELEASE.md)       | 2.60.0           | 10.0.1  | 2.16              | 1.16.1              | 1.16.1  |
 [1.15.0](https://github.com/tensorflow/transform/blob/v1.15.0/RELEASE.md)       | 2.47.0           | 10.0.0  | 2.15              | 1.15.0              | 1.15.1  |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,20 @@
 
 ## Bug Fixes and Other Changes
 
+## Breaking Changes
+
+## Deprecations
+
+# Version 1.21.0
+
+## Major Features and Improvements
+
+*   N/A
+
+## Bug Fixes and Other Changes
+
 *   Added support for Python 3.12 and 3.13.
+*   Pinned Bazel version to 7.7.0.
 *   Depends on `tensorflow>=2.21.0,<2.22.0`.
 *   Depends on `protobuf>=6.0.0,<7.0.0` for Python 3.11+.
 *   Updated `pyarrow` dependency to `>14`.
@@ -17,6 +30,8 @@
 *   Dropped support for Python 3.9.
 
 ## Deprecations
+
+*   N/A
 
 # Version 1.17.0
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -93,7 +93,8 @@ other *untested* combinations may also work.
 
 tensorflow-transform                                                            | apache-beam[gcp] | pyarrow | tensorflow        | tensorflow-metadata | tfx-bsl
 ------------------------------------------------------------------------------- | ---------------- | ------- | ----------------- | ------------------- | -------
-[GitHub master](https://github.com/tensorflow/transform/blob/master/RELEASE.md) | 2.65.0           | 10.0.1  | nightly (2.x)     | 1.17.1              | 1.17.1
+[GitHub master](https://github.com/tensorflow/transform/blob/master/RELEASE.md) | 2.72.0           | 14.0.0  | nightly (2.x)     | 1.21.0              | 1.21.0
+[1.21.0](https://github.com/tensorflow/transform/blob/v1.21.0/RELEASE.md)       | 2.72.0           | 14.0.0  | 2.21              | 1.21.0              | 1.21.0
 [1.17.0](https://github.com/tensorflow/transform/blob/v1.17.0/RELEASE.md)       | 2.65.0           | 10.0.1  | 2.17              | 1.17.1              | 1.17.1
 [1.16.0](https://github.com/tensorflow/transform/blob/v1.16.0/RELEASE.md)       | 2.60.0           | 10.0.1  | 2.16              | 1.16.1              | 1.16.1
 [1.15.0](https://github.com/tensorflow/transform/blob/v1.15.0/RELEASE.md)       | 2.47.0           | 10.0.0  | 2.15              | 1.15.0              | 1.15.1

--- a/setup.py
+++ b/setup.py
@@ -52,12 +52,17 @@ def _make_required_install_packages():
         "tensorflow>=2.21,<2.22",
         "tensorflow-metadata"
         + select_constraint(
-            default="@git+https://github.com/tensorflow/metadata@master",
-            nightly=">=1.18.0.dev",
+            default=">=1.21.0,<1.22.0",
+            nightly=">=1.22.0.dev",
             git_master="@git+https://github.com/tensorflow/metadata@master",
         ),
         "tf_keras>=2",
-        "tfx-bsl@git+https://github.com/tensorflow/tfx-bsl@master",
+        "tfx-bsl"
+        + select_constraint(
+            default=">=1.21.0,<1.22.0",
+            nightly=">=1.22.0.dev",
+            git_master="@git+https://github.com/tensorflow/tfx-bsl@master",
+        ),
     ]
 
 

--- a/tensorflow_transform/version.py
+++ b/tensorflow_transform/version.py
@@ -14,4 +14,4 @@
 """Contains the version string of TF.Transform."""
 
 # Note that setup.py uses this version.
-__version__ = "1.18.0.dev"
+__version__ = "1.22.0.dev"


### PR DESCRIPTION
# Align Master for 1.22.0 Development Cycle

Aligns the `master` branch for the `1.22.0` development cycle following the `1.21.0` release.

### Summary of Changes
* **Version Bump**: Bumped `__version__` in `tensorflow_transform/version.py` to `1.22.0.dev`.
* **Dependencies**: Configured `nightly` constraints to `>=1.22.0.dev` and aligned `default` constraints with stable `1.21.0` releases (`>=1.21.0,<1.22.0`) in `setup.py`.
* **Release Notes Archival**: Archived the `1.21.0` release notes in `RELEASE.md` and initialized clean, empty placeholders for the `Current Version` (1.22.0).
* **Documentation**: Updated compatibility tables in `README.md` and `docs/install.md` with `1.21.0` release entries and updated the Python version support badge (`3.10`–`3.13`).
* **Wheels Authentication**: Configured PyPI API token authentication in `.github/workflows/wheels.yml`.
